### PR TITLE
Add Write-AnsiHost function

### DIFF
--- a/PowerLine.psm1
+++ b/PowerLine.psm1
@@ -8,6 +8,8 @@ if(!("PowerLine.Prompt" -as [Type])) {
     Add-Type -Path (Join-Path $PSScriptRoot PowerLine.cs)
 }
 
+. (Join-Path $PSScriptRoot Write-AnsiHost.ps1)
+
 if(!$PowerLinePrompt) {
     [PowerLine.Prompt]$Script:PowerLinePrompt = @(,@(
         @{ bg = "Cyan";     fg = "White"; text = { $MyInvocation.HistoryId } },
@@ -261,13 +263,13 @@ function Set-PowerLinePrompt {
             }
         } catch {}
 
+        $prompt = $PowerLinePrompt.ToString($Host.UI.RawUI.BufferSize.Width)
         if($PowerLinePrompt.UseAnsiEscapes) {
-            $PowerLinePrompt.ToString($Host.UI.RawUI.BufferSize.Width)
+            $prompt
         } else {
-            Write-Host "No PowerLine for you! `$Host.UI.SupportsVirtualTerminal is false, and `$Env:ConEmuANSI` is not 'ON'" -ForegroundColor Red -BackgroundColor Black
-            return "> "
+            Write-AnsiHost -Text $prompt
         }
     }
 }
 
-Export-ModuleMember -Function Set-PowerLinePrompt, Get-Elapsed, Get-ShortenedPath, Test-Success, Test-Elevation, New-PowerLineBlock -Variable PowerLinePrompt
+Export-ModuleMember -Function Set-PowerLinePrompt, Get-Elapsed, Get-ShortenedPath, Test-Success, Test-Elevation, New-PowerLineBlock, Write-AnsiHost -Variable PowerLinePrompt

--- a/README.md
+++ b/README.md
@@ -98,16 +98,34 @@ This risks overlapping the output of the previous command, but ...
 There is a `New-PowerLineBlock` function which allows you to change the colors based on elevation, or the success of the last command.
 There are also `Test-Success` and `Test-Elevation` function if you just want to output something conditionally, or deal with it on your own.
 
-### Future Plans
+## Write-AnsiHost
+
+The `Write-AnsiHost` function provides support for ANSI VT escape sequences
+in Hosts that do not have native support. 
+The current implementation supports the color and cursor movement escape sequences.
+This function is used internally to provide support for hosts that do not support virtual terminals
+including the console prior to Windows 10 AU, Windows PowerShell ISE, and the integrated terminal in Visual Studio Code.
+
+There are known limitations for each of the downlevel hosts.
+
+### Console Prior to Windows 10
+* Consecutive calls to Write-Host with the NoNewline parameter will overlap the output of the prior call by a few pixels.
+
+### Windows PowerShell ISE
+* Prompt colors only support the default Windows console colors which don't match the provided color themes.
+* `PrefixLines` is not supported due to ISE's limited support of $Host.UI.RawUI.
+* The prompt is not anchored at the end of the last **left-aligned** column if the line also contains a **right-aligned** column.
+ This is also due to ISE's limited support of $Host.UI.RawUI.
+
+### Visual Studio Code (integrated terminal)
+* The `-PowerLineFont` switch is not supported due to issues displaying Unicode characters.
+
+## Future Plans
 
 If you have any questions, [please ask](https://github.com/jaykul/PowerLine/issues),
 and feel free to send me pull requests with additional escape sequences, or whatever.
 
 I would love help with a couple of things in particular:
-
-Currently my methods require the use of a `[ConsoleColor]`, and since those colors
-are also supported by the old-fashioned `Write-Host` command, I'm thinking about
-providing a `Write-PowerLine` function for compatibility with older versions of Windows and PowerShell.
 
 I expect that the next major Windows update to include full xterm color support,
 which ConEmu (and terminals on Linux and OSX) already support, so I'm thinking about

--- a/Write-AnsiHost.Tests.ps1
+++ b/Write-AnsiHost.Tests.ps1
@@ -1,0 +1,92 @@
+using namespace System.Collections.Generic
+Add-Type -Path .\PowerLine.cs
+. .\Write-AnsiHost.ps1
+
+function New-FakeHostWithCursorPosition {
+    param(
+        [int]$X,
+        [int]$Y
+    )
+
+    [PSCustomObject]@{
+        UI = [PSCustomObject]@{
+            RawUI = [PSCustomObject]@{
+                CursorPosition = New-Object -TypeName System.Management.Automation.Host.Coordinates -ArgumentList $X, $Y
+            }
+        }
+    }
+}
+
+Describe "Write-AnsiHost" {
+    Mock Write-Host {}
+
+    It "Processes the cursor up escape code" {
+        $y = Get-Random -Maximum 9999
+        $myHost = New-FakeHostWithCursorPosition -Y $y
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Minimum 1 -Maximum 9999
+        "$([char]0x1B)[$($n)A" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition.Y | Should Be ($y - $n)
+    }
+
+    It "Processes the cursor down escape code" {
+        $y = Get-Random -Maximum 9999
+        $myHost = New-FakeHostWithCursorPosition -Y $y
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Minimum 1 -Maximum 9999
+        "$([char]0x1B)[$($n)B" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition.Y | Should Be ($y + $n)
+    }
+
+    It "Processes the cursor forward escape code" {
+        $x = Get-Random -Maximum 9999
+        $myHost = New-FakeHostWithCursorPosition -X $x
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Minimum 1 -Maximum 9999
+        "$([char]0x1B)[$($n)C" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition.X | Should Be ($x + $n)
+    }
+
+    It "Processes the cursor back escape code" {
+        $x = Get-Random -Maximum 9999
+        $myHost = New-FakeHostWithCursorPosition -X $x
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Minimum 1 -Maximum 9999
+        "$([char]0x1B)[$($n)D" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition.X | Should Be ($x - $n)
+    }
+
+    It "Processes the cursor next line escape code" {
+        $y = Get-Random -Maximum 9999
+        $myHost = New-FakeHostWithCursorPosition -X (Get-Random -Minimum 1 -Maximum 9999) -Y $y
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Minimum 1 -Maximum 9999
+        "$([char]0x1B)[$($n)E" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition | Should Be (New-Object -TypeName System.Management.Automation.Host.Coordinates -ArgumentList 0, ($y + $n))
+    }
+
+    It "Processes the cursor previous line escape code" {
+        $y = Get-Random -Maximum 9999
+        $myHost = New-FakeHostWithCursorPosition -X (Get-Random -Minimum 1 -Maximum 9999) -Y $y
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Minimum 1 -Maximum 9999
+        "$([char]0x1B)[$($n)F)" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition | Should Be (New-Object -TypeName System.Management.Automation.Host.Coordinates -ArgumentList 0, ($y - $n))
+    }
+
+    It "Processes the cursor horizontal absolute escape code" {
+        $myHost = New-FakeHostWithCursorPosition -X (Get-Random -Maximum 9999)
+        Mock Get-Host { $myHost }
+        $n = Get-Random -Maximum 9999
+        "$([char]0x1B)[$($n)G" | Write-AnsiHost
+        $myHost.UI.RawUI.CursorPosition.X | Should Be ($n - 1)
+    }
+
+    It "Processes the color escape codes" {
+        $bg = [System.ConsoleColor](Get-Random -Maximum 15)
+        $fg = [System.ConsoleColor](Get-Random -Maximum 15)
+        $text = "PS"
+        Write-AnsiHost -Text ([PowerLine.AnsiHelper]::WriteAnsi($fg, $bg, $text))
+        Assert-MockCalled Write-Host 1 { $Object -eq $text -and $ForegroundColor -eq $fg -and $BackgroundColor -eq $bg } -Exactly
+    }
+}

--- a/Write-AnsiHost.ps1
+++ b/Write-AnsiHost.ps1
@@ -1,0 +1,150 @@
+function Write-AnsiHost {
+    <#
+    .Synopsis
+        Writes a string with ANSI VT escape sequences to the Host
+    .Description
+        Translates any ANSI VT escape sequences in the $Text parameter into the appropriate commands for the PS Host.
+
+        Currently only the color and cursor movement escape sequences are supported.
+    .Example
+        Write-AnsiHost -Text "$([char]0x1B)[91Error!"
+
+        This example produces the same output as Write-Host -Object "Error!" -ForegroundColor [System.ConsoleColor]::Red -NoNewline
+    .Example
+        "$([char]0x1B)[1AHeader" | Write-AnsiHost
+
+        This example produces the same output as the following series of commands:
+            $c = $Host.UI.RawUI.CursorPosition
+            $c.Y -= 1
+            $Host.UI.RawUI.CursorPosition = $c
+            Write-Host -Object "Header" -NoNewline
+    #>
+    param(
+        # The text with ANSI VT escape sequences to write to the Host
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)] [System.String[]] $Text
+    )
+
+    begin {
+        $bg = $fg = $null
+    }
+    process {
+        foreach ($item in $Text) {
+            foreach ($token in Get-AnsiTokens -Text $item) {
+                $param = Get-AnsiParameter -Value $token.data
+                if ("[A" -ceq $token.code) {
+                    if (!$param) { $param = 1 }
+                    Update-CursorPosition { $c.Y -= $param }
+                }
+                if ("[B" -ceq $token.code) {
+                    if (!$param) { $param = 1 }
+                    Update-CursorPosition { $c.Y += $param }
+                }
+                if ("[C" -ceq $token.code) {
+                    if (!$param) { $param = 1 }
+                    Update-CursorPosition { $c.X += $param }
+                }
+                if ("[D" -ceq $token.code) {
+                    if (!$param) { $param = 1 }
+                    Update-CursorPosition { $c.X -= $param }
+                }
+                if ("[E" -ceq $token.code) {
+                    if (!$param) { $param = 1 }
+                    Update-CursorPosition { $c.X = 0; $c.Y += $param }
+                }
+                if ("[F" -ceq $token.code) {
+                    if (!$param) { $param = 1 }
+                    Update-CursorPosition { $c.X = 0; $c.Y -= $param }
+                }
+                if ("[G" -ceq $token.code) {
+                    if ($param) { $param -= 1 }
+                    if (Test-Path variable:psISE) {
+                        $x = (Get-Host).UI.RawUI.CursorPosition.X
+                        if ($x -lt $param) { Write-Host -Object (" " * ($param - $x)) -NoNewline}
+                    } else {
+                        Update-CursorPosition { $c.X = $param }
+                    }
+                }
+                if ("[m" -ceq $token.code -and 30 -le $param -and 37 -ge $param) {
+                    $fg = $colors[$param - 30]
+                }
+                if ("[m" -ceq $token.code -and 40 -le $param -and 47 -ge $param) {
+                    $bg = $colors[$param - 40]
+                }
+                if ("[m" -ceq $token.code -and 90 -le $param -and 97 -ge $param) {
+                    $fg = $colors[$param - 90 + 8]
+                }
+                if ("[m" -ceq $token.code -and 100 -le $param -and 107 -ge $param) {
+                    $bg = $colors[$param - 100 + 8]
+                }
+                if ($null -eq $token.code -and -not [System.String]::IsNullOrEmpty($token.data)) {
+                    $params = @{ Object = $token.data }
+                    if ($null -ne $fg) { $params.Add("ForegroundColor", $fg) }
+                    if ($null -ne $bg) { $params.Add("BackgroundColor", $bg) }
+                    Write-Host -NoNewline @params
+                }
+            }
+        }
+    }
+}
+
+function Get-AnsiTokens {
+    param(
+        [Parameter(Mandatory=$true)] [string] $Text
+    )
+
+    $dataBufferStart = 0
+    $readingCsiData = $false
+    for ($i = 0; $i -lt $Text.Length; $i++) {
+        if ($readingCsiData -and 0x40 -le $Text.Chars($i) -and 0x7E -ge $Text.Chars($i)) {
+            [PSCustomObject]@{ code = "[" + $Text.Chars($i); data = $Text.Substring($dataBufferStart, $i - $dataBufferStart) }
+            $dataBufferStart = $i + 1
+            $readingCsiData = $false
+        }
+        if (0x1B -eq $Text.Chars($i) -and 0x40 -le $Text.Chars($i+1) -and 0x5F -ge $Text.Chars($i+1)) {
+            if ($i - $dataBufferStart -gt 0) { [PSCustomObject]@{ code = $null; data = $Text.Substring($dataBufferStart, $i - $dataBufferStart) } }
+            $dataBufferStart = ++$i + 1
+            if (0x5B -ne $Text.Chars($i)) { [PSCustomObject]@{ code = $Text.Chars($i); data = $null} } else { $readingCsiData = $true }
+        }
+    }
+    [PSCustomObject]@{ code = $null; data = $Text.Substring($dataBufferStart, $i - $dataBufferStart)}
+}
+
+function Get-AnsiParameter {
+    param(
+        [string] $Value
+    )
+
+    $result = 0
+    [int]::TryParse($Value, [ref]$result) | Out-Null
+    if (0 -gt $result) { $result = 0 }
+    $result
+}
+
+function Update-CursorPosition {
+    param (
+        [scriptblock]$updateFunction = {}
+    )
+
+    $c = (Get-Host).UI.RawUI.CursorPosition
+    & $updateFunction
+    (Get-Host).UI.RawUI.CursorPosition = $c
+}
+
+$colors = @(
+    [System.ConsoleColor]::Black
+    [System.ConsoleColor]::DarkRed
+    [System.ConsoleColor]::DarkGreen
+    [System.ConsoleColor]::DarkYellow
+    [System.ConsoleColor]::DarkBlue
+    [System.ConsoleColor]::DarkMagenta
+    [System.ConsoleColor]::DarkCyan
+    [System.ConsoleColor]::Gray
+    [System.ConsoleColor]::DarkGray
+    [System.ConsoleColor]::Red
+    [System.ConsoleColor]::Green
+    [System.ConsoleColor]::Yellow
+    [System.ConsoleColor]::Blue
+    [System.ConsoleColor]::Magenta
+    [System.ConsoleColor]::Cyan
+    [System.ConsoleColor]::White
+)


### PR DESCRIPTION
This function provides support for ANSI VT escape codes in hosts that do not support VT100 like virtual terminals. Currently only supports the color and cursor movement escape codes.
