### PR TITLE
Adding support for restoration of Virtual Terminal Processing

### DIFF
--- a/Source/CSharp/ConsoleMode.cs
+++ b/Source/CSharp/ConsoleMode.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PowerLine
+{
+	[Flags]
+	enum ConsoleOutputModes : uint
+	{
+		ENABLE_PROCESSED_OUTPUT = 0x0001,
+		ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002,
+		ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004,
+		DISABLE_NEWLINE_AUTO_RETURN = 0x0008,
+		ENABLE_LVB_GRID_WORLDWIDE = 0x0010,
+	}
+
+	public static class ConsoleMode
+	{
+		const int STD_OUTPUT_HANDLE = -11;
+		public static void RestoreVirtualTerminal()
+		{
+			var outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+			ConsoleOutputModes mode;
+			if (!GetConsoleMode(outHandle, out mode))
+			{
+				mode = ConsoleOutputModes.ENABLE_PROCESSED_OUTPUT | ConsoleOutputModes.ENABLE_WRAP_AT_EOL_OUTPUT;
+			}
+
+			mode |= ConsoleOutputModes.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+			SetConsoleMode(outHandle, (uint)mode);
+		}
+
+		[DllImport("kernel32.dll")]
+		static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+		[DllImport("kernel32.dll")]
+		static extern bool GetConsoleMode(IntPtr hConsoleHandle, out ConsoleOutputModes mode);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		static extern IntPtr GetStdHandle(int nStdHandle);
+	}
+}

--- a/Source/CSharp/Prompt.cs
+++ b/Source/CSharp/Prompt.cs
@@ -23,6 +23,7 @@ namespace PowerLine
         public ScriptBlock Title { get; set; }
         public bool SetCurrentDirectory { get; set; }
         public bool UseAnsiEscapes { get; set; }
+        public bool RestoreVirtualTerminal { get; set; }
         public int PrefixLines { get; set; }
 
         public Prompt()

--- a/Source/PowerLine.psd1
+++ b/Source/PowerLine.psd1
@@ -4,7 +4,7 @@
 RootModule = 'PowerLine.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.1.2'
+ModuleVersion = '2.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -70,7 +70,8 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
-        Add -UseAnsiEscapes switch for controlling the use of VT escape sequences (in preparation for adding a Write-Host adapter)
+        2.2.0: Add -RestoreVirtualTerminal switch for controlling if the prompt should reenable VT processing after each command
+        2.1.0: Add -UseAnsiEscapes switch for controlling the use of VT escape sequences (in preparation for adding a Write-Host adapter)
         Add pre-compiled assembly for .Net Core
         '
     } # End of PSData hashtable

--- a/Source/Public/Set-PowerLinePrompt.ps1
+++ b/Source/Public/Set-PowerLinePrompt.ps1
@@ -39,6 +39,10 @@ function Set-PowerLinePrompt {
         # If true, override the default testing for ANSI consoles and force the use of Escape Sequences rather than Write-Host
         [Parameter()]
         [switch]$UseAnsiEscapes = $($Host.UI.SupportsVirtualTerminal -or $Env:ConEmuANSI -eq "ON")
+
+        # If true, adds ENABLE_VIRTUAL_TERMINAL_PROCESSING to the console output mode. Useful on PowerShell versions that don't restore the console 
+        [Parameter()]
+        [switch]$RestoreVirtualTerminal
     )
     if($null -eq $script:OldPrompt) {
         $script:OldPrompt = $function:global:prompt
@@ -54,6 +58,7 @@ function Set-PowerLinePrompt {
     }
 
     $global:PowerLinePrompt.UseAnsiEscapes = $UseAnsiEscapes
+    $global:PowerLinePrompt.RestoreVirtualTerminal = $RestoreVirtualTerminal 
 
 
     if($ResetSeparators -or ($PSBoundParameters.ContainsKey("PowerLineFont") -and !$PowerLineFont) ) {
@@ -91,6 +96,9 @@ function Set-PowerLinePrompt {
             }
         } catch {}
 
+        if ($PowerLinePrompt.RestoreVirtualTerminal) {
+                [PowerLine.ConsoleMode]::RestoreVirtualTerminal()
+        }
         if($PowerLinePrompt.UseAnsiEscapes) {
             $PowerLinePrompt.ToString($Host.UI.RawUI.BufferSize.Width)
         } else {


### PR DESCRIPTION
Native commands, like perl (which is used by git) may change the console output mode and remote support for virtual terminal processing. 
This make the prompt just look like garbage.
Adding switch -RestoreVirtualTerminal and changing prompt function to check for the flag.