### PR TITLE
Adding empty CmdletsToExport specification

### DIFF
--- a/Source/PowerLine.psd1
+++ b/Source/PowerLine.psd1
@@ -46,7 +46,7 @@ RequiredModules = @(
 FunctionsToExport = 'Set-PowerLinePrompt', 'Write-PowerlinePrompt', 'Export-PowerLinePrompt', 'Add-PowerLineBlock', 'Remove-PowerLineBlock', 'New-PromptText', 'Get-Elapsed', 'Get-SegmentedPath', 'Get-ShortenedPath', 'Test-Success', 'Test-Elevation'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-# CmdletsToExport = '*'
+CmdletsToExport = ''
 
 # Variables to export from this module
 # VariablesToExport = 'PowerLineColors'


### PR DESCRIPTION
When this isn't specified, powershell loads the module when auto-discovering commands.