### PR TITLE
updated Test-Elevation to use correct IsMaxOs variable

### DIFF
--- a/Source/Public/Test-Elevation.ps1
+++ b/Source/Public/Test-Elevation.ps1
@@ -5,7 +5,7 @@ function Test-Elevation {
     #>
     [CmdletBinding()]
     param()
-    if(-not ($IsLinux -or $IsOSX)) {
+    if(-not ($IsLinux -or $IsMacOS)) {
         [Security.Principal.WindowsIdentity]::GetCurrent().Owner.IsWellKnown("BuiltInAdministratorsSid")
     } else {
         0 -eq (id -u)


### PR DESCRIPTION
errors where thrown after import due to the wrong automatic variable for osx was used. This fixes that issue