### PR TITLE
fix(unix): Fix `Get‑SegmentedPath` on Unix

### DIFF
--- a/Source/Public/Get-SegmentedPath.ps1
+++ b/Source/Public/Get-SegmentedPath.ps1
@@ -53,7 +53,8 @@ function Get-SegmentedPath {
         } else {
             @{ Object = (Split-Path $Path -Leaf) -replace "[\\/]$" }
         }
-        $Path = Split-Path $Path
+        # See https://github.com/PowerShell/PowerShell/issues/10092
+        $Path = if ($Path -eq "/") { "" } else { Split-Path $Path }
 
         Write-Verbose $Path
 


### PR DESCRIPTION
See https://github.com/PowerShell/PowerShell/issues/10092 for details.

On Windows, `Split-Path '/'` already returns the empty string.