### PR TITLE
Fix right-aligned blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ All you need to to is start adding things to your `$Prompt` -- you can do that d
 
 #### Right-aligned blocks
 
-If you add a scriptblock that outputs _just_ a tab `{ "``t" }`,
-blocks after that will be right-aligned until the next block which is _just_ a newline `{ "``n" }`.
+If you add a scriptblock that outputs _just_ a tab ``{ "`t" }``,
+blocks after that will be right-aligned until the next block which is _just_ a newline ``{ "`n" }``.
 
 For Right-aligned blocks, the "ReverseColorSeparator" or "ReverseSeparator" characters are used instead of the "ColorSeparator" and "Separator".
 

--- a/Source/Public/Write-PowerlinePrompt.ps1
+++ b/Source/Public/Write-PowerlinePrompt.ps1
@@ -3,6 +3,8 @@ function Write-PowerlinePrompt {
     param()
 
     try {
+        $escape =  [char]0x001b
+
         # FIRST, make a note if there was an error in the previous command
         [bool]$script:LastSuccess = $?
         $PromptErrors = [ordered]@{}
@@ -140,7 +142,7 @@ function Write-PowerlinePrompt {
                     $lineLength = ($line -replace "\u001B.*?\p{L}").Length
                     $Align = $BufferWidth - $lineLength
                     #Write-Debug "The buffer is $($BufferWidth) wide, and the line is $($lineLength) long so we're aligning to $($Align)"
-                    $result += [PoshCode.Pansies.Text]::new("&Esc;$($Align)G ")
+                    $result += "$($escape)[s" + [PoshCode.Pansies.Text]::new("&Esc;$($Align)G ")
                     $RightAligned = $False
                 } else {
                     $line += [PoshCode.Pansies.Text]@{
@@ -150,7 +152,7 @@ function Write-PowerlinePrompt {
                     }
                 }
                 $extraLineCount++
-                $result += $line + "`n"
+                $result += "$($line)$($escape)[u"
                 $line = ""
                 $ColorSeparator = "&ColorSeparator;"
                 $Separator = "&Separator;"

--- a/Source/Public/Write-PowerlinePrompt.ps1
+++ b/Source/Public/Write-PowerlinePrompt.ps1
@@ -124,7 +124,7 @@ function Write-PowerlinePrompt {
                     ## Before the (column) break, add a cap
                     #Write-Debug "Pre column-break, add a $LastBackground cap"
                     $line += [PoshCode.Pansies.Text]@{
-                        Object          = "$ColorSeparator "
+                        Object          = "$ColorSeparator"
                         ForegroundColor = $LastBackground
                         BackgroundColor = $Host.UI.RawUI.BackgroundColor
                     }
@@ -142,7 +142,7 @@ function Write-PowerlinePrompt {
                     $lineLength = ($line -replace "\u001B.*?\p{L}").Length
                     $Align = $BufferWidth - $lineLength
                     #Write-Debug "The buffer is $($BufferWidth) wide, and the line is $($lineLength) long so we're aligning to $($Align)"
-                    $result += "$($escape)[s" + [PoshCode.Pansies.Text]::new("&Esc;$($Align)G ")
+                    $result += "$($escape)[s" + [PoshCode.Pansies.Text]::new("&Esc;$($Align)G")
                     $RightAligned = $False
                 } else {
                     $line += [PoshCode.Pansies.Text]@{
@@ -191,7 +191,7 @@ function Write-PowerlinePrompt {
         # create the number of lines we need for output up front:
         ("`n" * $extraLineCount) + ("$([char]27)M" * $extraLineCount) +
         $PromptErrorString + $result + $line + ([PoshCode.Pansies.Text]@{
-            Object          = "$([char]27)[49m$ColorSeparator&Clear;"
+            Object          = if($extraLineCount -gt 0) {"$([char]27)[49m&Clear;" } else { "$([char]27)[49m$ColorSeparator&Clear;" }
             ForegroundColor = $LastBackground
         })
     } catch {


### PR DESCRIPTION
This commit fixes right-aligned blocks in order to be closer to the unix shell implementation of Powerline.

Instead of adding a newline:
* we save the current cursor position using the ANSI escape char "ESC[s"
* write the right-aligned block
* restore the previous cursor position using the ANSI escape char "ESC[u"

more details : [ANSI_escape_code#Terminal_output_sequences](https://en.wikipedia.org/wiki/ANSI_escape_code#Terminal_output_sequences)