### PR TITLE
Specify -format parameter when using Get-Date

### DIFF
--- a/Source/Examples/Sample.ps1
+++ b/Source/Examples/Sample.ps1
@@ -3,7 +3,7 @@
 $global:prompt = @(
     { "`t" } # On the first line, right-justify
     { New-PowerLineBlock (Get-Elapsed) -ErrorBackgroundColor DarkRed -ErrorForegroundColor White -ForegroundColor Black -BackgroundColor DarkGray }
-    { Get-Date -f "T" }
+    { Get-Date -format "T" }
     { "`n" } # Start another line
     { $MyInvocation.HistoryId }
     { "&Gear;" * $NestedPromptLevel }

--- a/Source/Examples/SampleForConsolas.ps1
+++ b/Source/Examples/SampleForConsolas.ps1
@@ -7,7 +7,7 @@
 $global:Prompt = @(
     { "`t" } # On the first line, right-justify
     { Get-Elapsed }
-    { Get-Date -f "T" }
+    { Get-Date -format "T" }
     { "`n" } # Start another line
     { $MyInvocation.HistoryId }
     { "&Gear;" * $NestedPromptLevel }

--- a/Source/Public/Set-PowerLinePrompt.ps1
+++ b/Source/Public/Set-PowerLinePrompt.ps1
@@ -155,7 +155,7 @@ function Set-PowerLinePrompt {
             if($Timestamp) {
                 { "`t" }
                 { Get-Elapsed }
-                { Get-Date -f "T" }
+                { Get-Date -format "T" }
             }
             { "`n" }
             { New-PromptText { "I $(New-PromptText -Fg Red -EFg White "&hearts;$([char]27)[30m") PS" } -Bg White -EBg Red -Fg Black }


### PR DESCRIPTION
The `Get-Date` cmdlet has been updated with a new parameter, `-FromUnixTime`.

Because of this, using `-f` is ambiguous. My proposal is to change instances of this to `-format`. This will ensure no ambiguity when used.

For example: 
`{ Get-Date -f "T" }` becomes  `{ Get-Date -format "T" }`

Fix: #62 



