### PR TITLE
Fix $Host BackgroundColor in Write-PowerLinePrompt for Mac/Linux hosts

### DIFF
--- a/Source/Public/Write-PowerlinePrompt.ps1
+++ b/Source/Public/Write-PowerlinePrompt.ps1
@@ -146,7 +146,7 @@ function Write-PowerlinePrompt {
                     $line += [PoshCode.Pansies.Text]@{
                         Object          = $ColorSeparator
                         ForegroundColor = $LastBackground
-                        BackgroundColor = $Host.UI.RawUI.BackgroundColor
+                        BackgroundColor = $Host.UI.RawUI.BackgroundColor -eq -1 ? $null : $Host.UI.RawUI.BackgroundColor
                     }
                 }
                 $extraLineCount++


### PR DESCRIPTION
On Mac or Linux PowerShell Core, `$Host.UI.RawUI.BackgroundColor` returns -1 which results in an index out of range error when converting to `PoshCode.Pansies.Text`. This fix returns $null if background color comes back as -1; otherwise, it behaves as it used to.

Fixes #60.